### PR TITLE
Make extraction regexp faster

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -6,7 +6,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.capture = capture;
 exports.fromStack = fromStack;
-const extractionRegex = /at (.*?) \((.*?):(\d+):(\d+)\)/;
+const extractionRegex = /at (\S+) \((\S+):(\d+):(\d+)\)/;
 
 function capture() {
   const traces = fromStack(new Error().stack);

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 'use babel'
 
-const extractionRegex = /at (.*?) \((.*?):(\d+):(\d+)\)/
+const extractionRegex = /at (\S+) \((\S+):(\d+):(\d+)\)/
 
 export function capture() {
   const traces = fromStack(new Error().stack)


### PR DESCRIPTION
From 370 steps to 136 steps

Example text to test on

```
Error
    at <anonymous>:2:1
    at Object.InjectedScript._evaluateOn (<anonymous>:875:140)
    at Object.InjectedScript._evaluateAndWrap (<anonymous>:808:34)
    at Object.InjectedScript.evaluate (<anonymous>:664:21)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/steelbrain/callsite/2)

<!-- Reviewable:end -->
